### PR TITLE
 ERROR  [Vue warn]が出なくなる様にしました。

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -31,7 +31,7 @@
                   <!-- eslint-disable vue/no-v-html-->
                   <span v-html="$t('軽症・<br />中等症')" />
                   <!-- eslint-enable vue/no-v-html-->
-                  <span v-if="軽症中等症 !== null" >
+                  <span v-if="軽症中等症 !== null">
                     <strong>{{ 軽症中等症 }}</strong>
                     <span :class="$style.unit">{{ $t('人') }}</span>
                   </span>
@@ -43,7 +43,7 @@
               <div :class="$style.pillar">
                 <div :class="$style.content">
                   <span>{{ $t('重症') }}</span>
-                  <span v-if="重症 !== null" >
+                  <span v-if="重症 !== null">
                     <strong>{{ 重症 }}</strong>
                     <span :class="$style.unit">{{ $t('人') }}</span>
                   </span>

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -31,10 +31,11 @@
                   <!-- eslint-disable vue/no-v-html-->
                   <span v-html="$t('軽症・<br />中等症')" />
                   <!-- eslint-enable vue/no-v-html-->
-                  <span>
+                  <span v-if="軽症中等症 !== null" >
                     <strong>{{ 軽症中等症 }}</strong>
                     <span :class="$style.unit">{{ $t('人') }}</span>
                   </span>
+                  <span v-else> --- </span>
                 </div>
               </div>
             </li>
@@ -42,10 +43,11 @@
               <div :class="$style.pillar">
                 <div :class="$style.content">
                   <span>{{ $t('重症') }}</span>
-                  <span>
+                  <span v-if="重症 !== null" >
                     <strong>{{ 重症 }}</strong>
                     <span :class="$style.unit">{{ $t('人') }}</span>
                   </span>
+                  <span v-else> --- </span>
                 </div>
               </div>
             </li>

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -97,11 +97,11 @@ export default Vue.extend({
       required: true
     },
     軽症中等症: {
-      type: Number,
+      validator: prop => typeof prop === 'number' || prop === null,
       required: true
     },
     重症: {
-      type: Number,
+      validator: prop => typeof prop === 'number' || prop === null,
       required: true
     },
     死亡: {


### PR DESCRIPTION
こちらを参考にnullも許可する様にしました。
https://qiita.com/tanaka174/items/13991eb6ae701c876809

```
 ERROR  [Vue warn]: Invalid prop: type check failed for prop "軽症中等症". Expected Number with value 0, got Null

found in

---> <ConfirmedCasesTable> at components/ConfirmedCasesTable.vue
       <VCard>
         <DataView> at components/DataView.vue
           <ConfirmedCasesCard> at components/ConfirmedCasesCard.vue
             <ConfirmedCasesDetailsCard> at components/cards/ConfirmedCasesDetailsCard.vue
               <Pages/index.vue> at pages/index.vue
                 <Nuxt>
                   <VApp>
                     <Layouts/default.vue> at layouts/default.vue
                       <Root>

 ERROR  [Vue warn]: Invalid prop: type check failed for prop "重症". Expected Number with value 0, got Null

found in

---> <ConfirmedCasesTable> at components/ConfirmedCasesTable.vue
       <VCard>
         <DataView> at components/DataView.vue
           <ConfirmedCasesCard> at components/ConfirmedCasesCard.vue
             <ConfirmedCasesDetailsCard> at components/cards/ConfirmedCasesDetailsCard.vue
               <Pages/index.vue> at pages/index.vue
                 <Nuxt>
                   <VApp>
                     <Layouts/default.vue> at layouts/default.vue
                       <Root>
```
